### PR TITLE
Gesture Anywhere: Fix wrong value being set.

### DIFF
--- a/src/com/gzr/wolvesden/gestureanywhere/GestureAnywhereSettings.java
+++ b/src/com/gzr/wolvesden/gestureanywhere/GestureAnywhereSettings.java
@@ -76,7 +76,7 @@ public class GestureAnywhereSettings extends SettingsPreferenceFragment implemen
         mTriggerWidthPref.setOnPreferenceChangeListener(this);
 
         mTriggerTopPref = (CustomSeekBarPreference) findPreference(KEY_TRIGGER_TOP);
-        mTriggerWidthPref.setValue(Settings.System.getInt(getContentResolver(),
+        mTriggerTopPref.setValue(Settings.System.getInt(getContentResolver(),
                 Settings.System.GESTURE_ANYWHERE_TRIGGER_TOP, 0));
         mTriggerTopPref.setOnPreferenceChangeListener(this);
 


### PR DESCRIPTION
Every time we change the value of the Gesture Anywhere's Trigger Position, its value gets saved to "Trigger Width" instead and the Position's value defaults to 0.